### PR TITLE
Remove default keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,8 @@ Plug 'dwrdx/mywords.nvim'
 
 ## How to use
 
-|Key Mapping|Function|
-|-----------|--------|
-| \<leader\>m | Toggle highlight of the word under cursor|
-| \<leader\>c | Clear all highlights|
+configuire your own key mappings in init.vim
 
-
-or configuire your own key mappings in init.vim
 ``` 
 map <silent> <leader>m :lua require'mywords'.hl_toggle()<CR>
 map <silent> <leader>c :lua require'mywords'.uhl_all()<CR>

--- a/lua/mywords.lua
+++ b/lua/mywords.lua
@@ -88,20 +88,6 @@ local function hl_toggle()
     highlight_word(word)
 end
 
--- helper to create key mapping
-local function key_mapping_helper(mode, lhs, rhs, opts)
-    local options = { noremap = true }
-    if opts then
-        options = vim.tbl_extend("force", options, opts)
-    end
-    vim.api.nvim_set_keymap(mode, lhs, rhs, options)
-end
-
-
-key_mapping_helper("n", "<leader>m", ":lua require'mywords'.hl_toggle()<CR>", { silent = true })
-key_mapping_helper("n", "<leader>c", ":lua require'mywords'.uhl_all()<CR>",   { silent = true })
-
-
 return {
   hl_toggle = hl_toggle,
   uhl_all = uhl_all 


### PR DESCRIPTION
The default hardcoded keymapping is easily conflict with user's configuration.